### PR TITLE
Removed old dynamictoolwidget references from qmake pro file

### DIFF
--- a/buildFiles/common/projectmanager_files.pro
+++ b/buildFiles/common/projectmanager_files.pro
@@ -10,7 +10,6 @@ QT += network xml
 
 # Input
 HEADERS += ../../source/copyDir.h \
-           ../../source/dynamictoolwidget.h \
            ../../source/NewProjectPage.h \
            ../../source/PlatformCheck.h \
            ../../source/ProgressDialog.h \
@@ -26,7 +25,6 @@ FORMS += ../../source/NewProjectPage.ui \
          ../../source/ProjectTreeItem.ui \
          ../../source/torque3dfrontloader.ui
 SOURCES += ../../source/copyDir.cpp \
-           ../../source/dynamictoolwidget.cpp \
            ../../source/main.cpp \
            ../../source/NewProjectPage.cpp \
            ../../source/PlatformCheck.cpp \


### PR DESCRIPTION
References to the old dynamictoolwidget files were left in buildFiles/common/projectmanager_files.pro.  This prevented compiling of the Project Manager.  This fix removes the references.  Any Visual Studio project files will need to be rebuild by running qmake again.
