### PR TITLE
Packages

### DIFF
--- a/source/NewProjectPage.cpp
+++ b/source/NewProjectPage.cpp
@@ -52,16 +52,16 @@ void NewProjectPage::setDefaults()
 
 void NewProjectPage::buildTemplateList()
 {
-   QMultiMap<QString, ProjectEntry*> *dirList = mFrontloader->getProjectList()->getTemplateDirectoryList();
+   QMultiMap<QString, TemplateEntry*> *dirList = mFrontloader->getProjectList()->getTemplateDirectoryList();
 
-   QList<ProjectEntry*> entryList = dirList->values("Templates");
+   QList<TemplateEntry*> entryList = dirList->values("Templates");
 
    mTemplateNameList.clear();
    TemplateList->clear();
 
    for(int i=0; i<entryList.size(); i++)
    {
-      ProjectEntry *entry = entryList.at(i);
+      TemplateEntry *entry = entryList.at(i);
 
       if(mTemplateNameList.values(entry->mName).size() == 0)
       {
@@ -88,7 +88,7 @@ void NewProjectPage::buildTemplateList()
 
 void NewProjectPage::on_TemplateList_textChanged(const QString &text)
 {
-   ProjectEntry *entry = mTemplateNameList.value(text);
+   TemplateEntry *entry = mTemplateNameList.value(text);
 
    if(entry != NULL)
    {
@@ -141,7 +141,7 @@ void NewProjectPage::on_newProjectCreateButton_clicked()
 {
    if(mFrontloader != NULL)
    {
-      ProjectEntry *entry = mTemplateNameList.value(TemplateList->currentText());
+      TemplateEntry *entry = mTemplateNameList.value(TemplateList->currentText());
 
       //If a project with no path is specified, the project will delete the "My Projects"
       //Folder and then present the user with an error that the project couldn't be created.

--- a/source/NewProjectPage.cpp
+++ b/source/NewProjectPage.cpp
@@ -156,7 +156,8 @@ void NewProjectPage::on_newProjectCreateButton_clicked()
       {
          QString templatePath = QDir::toNativeSeparators(entry->mRootPath);
          QString newProjectPath = QDir::toNativeSeparators(DirectoryTextEdit->text() + "/" + NameTextEdit->text());
-         mFrontloader->createNewProject(templatePath, newProjectPath, mCurrentInstance);
+         QStringList packagePaths = entry->mRecommendedPackages + entry->mRequiredPackages;
+         mFrontloader->createNewProject(templatePath, packagePaths, newProjectPath, mCurrentInstance);
       }
    }
 }

--- a/source/NewProjectPage.h
+++ b/source/NewProjectPage.h
@@ -7,7 +7,7 @@
 using namespace Ui;
 
 class Torque3DFrontloader;
-class ProjectEntry;
+class TemplateEntry;
 class ModuleListInstance;
 
 class NewProjectPage : public QWidget, public NewProjectPageClass
@@ -16,7 +16,7 @@ class NewProjectPage : public QWidget, public NewProjectPageClass
 
 private:
    Torque3DFrontloader *mFrontloader;
-   QMap<QString, ProjectEntry*> mTemplateNameList;
+   QMap<QString, TemplateEntry*> mTemplateNameList;
    ModuleListInstance* mCurrentInstance;
 
 public:

--- a/source/copyDir.cpp
+++ b/source/copyDir.cpp
@@ -5,22 +5,31 @@ void CopyDir::run()
 {  
    mPause = false;
    mExitNow = false;
-   bool success = copyDirAndFiles(mSrcDir, mDstDir, &mNameExcludeFilter, &mNameIncludeFilter);
+   bool success = true;
 
-   mutex.lock();
-   if(mPause)
+   QStringList::const_iterator it;
+   for(it = mSrcDirs.cbegin(); it != mSrcDirs.cend(); ++it)
    {
-      pauseThreads.wait(&mutex);
+      QString srcDir = *it;
+      mRootDir = srcDir;
+      success &= copyDirAndFiles(srcDir, mDstDir, &mNameExcludeFilter, &mNameIncludeFilter);
+
+      if(!success) break;
+
+      mutex.lock();
+      if(mPause)
+      {
+         pauseThreads.wait(&mutex);
+      }
+      mutex.unlock();
    }
-   mutex.unlock();
    
    emit fileCopyDone(success, mExitNow);
 }
 
-void CopyDir::setValues(QString srcDir, QString dstDir, QStringList nameExcludeFilter, QStringList nameIncludeFilter)
+void CopyDir::setValues(QStringList srcDirs, QString dstDir, QStringList nameExcludeFilter, QStringList nameIncludeFilter)
 {
-   mRootDir = srcDir;
-   mSrcDir = srcDir;
+   mSrcDirs = srcDirs;
    mDstDir = dstDir;
    mNameExcludeFilter = nameExcludeFilter;
    mNameIncludeFilter = nameIncludeFilter;

--- a/source/copyDir.h
+++ b/source/copyDir.h
@@ -13,7 +13,7 @@ class CopyDir : public QThread
 
 public:
    void run();	  
-   void setValues(QString srcDir, QString dstDir, QStringList nameExcludeFilter = QStringList(), QStringList nameIncludeFilter = QStringList());
+   void setValues(QStringList srcDirs, QString dstDir, QStringList nameExcludeFilter = QStringList(), QStringList nameIncludeFilter = QStringList());
    bool copyDirAndFiles(QString srcDir, QString dstDir, QStringList *nameExcludeFilter, QStringList *nameIncludeFilter, QStringList *srcFileList = NULL, QStringList *dstFileList = NULL);
 
 signals:
@@ -28,7 +28,7 @@ public slots:
 
 private:
    QString mRootDir;
-   QString mSrcDir;
+   QStringList mSrcDirs;
    QString mDstDir;
    QStringList mNameExcludeFilter;
    QStringList mNameIncludeFilter;

--- a/source/projectList.cpp
+++ b/source/projectList.cpp
@@ -63,7 +63,6 @@ void ProjectList::buildList()
    QDomDocument doc("projects");
 
    QString baseAppPath = getAppPath();
-   //QString projectsPath = baseAppPath + "/Engine/bin/tools/projects.xml";
    QString projectsPath = baseAppPath + "projects.xml";
    QFile file(projectsPath);
       
@@ -244,15 +243,14 @@ void ProjectList::buildList()
 void TemplateEntry::findPackages()
 {
    static const QString templateFileName = "template.xml";
+   static const QString packageDirName = "Packages";
 
    // Load in the xml file, parse it, and build out the controls
    QDomDocument doc("template");
 
    QString basePath = mRootPath;
-   //QString projectsPath = baseAppPath + "/Engine/bin/tools/projects.xml";
-   QString templatePath = basePath + "/" + templateFileName;
+   QString templatePath = basePath + QDir::separator() + templateFileName;
    QFile file(templatePath);
-   std::string debug = templatePath.toStdString();
 
    if (!file.open(QIODevice::ReadOnly))
    {
@@ -267,7 +265,6 @@ void TemplateEntry::findPackages()
 
    file.close();
 
-   // Process
    QDomElement docElem = doc.documentElement();
    QDomNode n = docElem.firstChild();
    while(!n.isNull())
@@ -275,19 +272,20 @@ void TemplateEntry::findPackages()
       QDomElement e = n.toElement();
       if(!e.isNull() && e.tagName() == "package")
       {
-         // projectDirectory
          if(e.hasAttribute("path") && e.hasAttribute("inclusion"))
          {
             QString title = e.attribute("path");
             QString inclusion = e.attribute("inclusion");
+            QDir packageDir(packageDirName + QDir::separator() + title);
+            QString path = packageDir.absolutePath();
 
             if(inclusion == "required")
             {
-               mRequiredPackages.append(title);
+               mRequiredPackages.append(path);
             }
             else if(inclusion == "recommended")
             {
-               mRecommendedPackages.append(title);
+               mRecommendedPackages.append(path);
             }
          }
       }

--- a/source/projectList.h
+++ b/source/projectList.h
@@ -8,18 +8,31 @@
 #include <comdef.h>
 #endif
 
-class ProjectEntry
+class DirEntry
 {
 public:
-   QString    mPath;
-   QString    mName;
-   QString    mRootName;
-   QString    mRootPath;
-   QString    mArgs;
+   QString mPath;
+   QString mName;
+   QString mRootName;
+   QString mRootPath;
 
    QString getUniqueName() { return QString(mRootName + "-" + mName); };
    QString getAppPath();
+};
+
+class ProjectEntry : public DirEntry
+{
+public:
+   QString mArgs;
    QString getLevelPath();
+};
+
+class TemplateEntry : public DirEntry
+{
+public:
+   QList<QString> mRequiredPackages;
+   QList<QString> mRecommendedPackages;
+   void findPackages();
 };
 
 /* ProjectList
@@ -99,8 +112,8 @@ public:
    QMultiMap<QString, ProjectEntry*>      *getProjectDirectoryList() { return &mProjectDirectoryList; };
    QList<ProjectEntry*>                   *getProjectFileList() { return &mProjectFileList; };
 
-   QMultiMap<QString, ProjectEntry*>      mTemplateDirectoryList;
-   QMultiMap<QString, ProjectEntry*>      *getTemplateDirectoryList() { return &mTemplateDirectoryList; };
+   QMultiMap<QString, TemplateEntry*>      mTemplateDirectoryList;
+   QMultiMap<QString, TemplateEntry*>      *getTemplateDirectoryList() { return &mTemplateDirectoryList; };
 
    void toggleEditor(int editorMode);
    ProjectEntry *getFirstProjectEntry();

--- a/source/torque3dfrontloader.cpp
+++ b/source/torque3dfrontloader.cpp
@@ -1375,7 +1375,7 @@ void Torque3DFrontloader::projectCategoryRemoved(QString title)
 }
 
 
-QPixmap *Torque3DFrontloader::getProjectPixmap(ProjectEntry *entry)
+QPixmap *Torque3DFrontloader::getProjectPixmap(DirEntry *entry)
 {
    QPixmap *pixmap = NULL;
    QFile thumb(entry->mRootPath + QDir::separator() + "thumb.png");

--- a/source/torque3dfrontloader.cpp
+++ b/source/torque3dfrontloader.cpp
@@ -668,7 +668,9 @@ void Torque3DFrontloader::packageProjectStaging()
       connect(&mCopyDir, SIGNAL(fileCopyDone(bool, bool)), this, SLOT(updateStagingFileDone(bool, bool)));
       connect(&mCopyDir, SIGNAL(fileCopyDone(bool, bool)), &mCopyDir, SLOT(quit()));
 
-      mCopyDir.setValues(rootProjectPath.path(), outputDir.path(), nameExcludeFilter, nameIncludeFilter);
+      QStringList dirs;
+      dirs.push_front(rootProjectPath.path());
+      mCopyDir.setValues(dirs, outputDir.path(), nameExcludeFilter, nameIncludeFilter);
       mCopyDir.start();
    }
 }
@@ -715,7 +717,7 @@ void Torque3DFrontloader::createProjectCheck()
    setSelectedProjectByUniqueName(uniqueName, false);
 }
 
-void Torque3DFrontloader::createNewProject(const QString &templatePath, const QString &newProjectPath, ModuleListInstance* moduleInst)
+void Torque3DFrontloader::createNewProject(const QString &templatePath, const QStringList &packagePaths, const QString &newProjectPath, ModuleListInstance* moduleInst)
 {
    // init values
    mCreateTemplateCopyDone = false;
@@ -730,6 +732,7 @@ void Torque3DFrontloader::createNewProject(const QString &templatePath, const QS
 
    mTemplateDir.setPath(templatePath);
    mNewProjectDir.setPath(newProjectPath);
+   mPackagePaths = packagePaths;
 
    mNewProjectModuleList = moduleInst;
 
@@ -881,17 +884,19 @@ void Torque3DFrontloader::createTemplateCopy()
       mNewProjectDir.mkdir(mNewProjectDir.path());
 
    // our new project path exists, time to copy everything we want over to it
-   mTemplateDir.setFilter(QDir::AllDirs | QDir::Files | QDir::Hidden);
    QStringList nameExcludeFilter;
    nameExcludeFilter << "*.obj" << "*.exp" << "*.ilk" << "*.pch" << "*.sbr" << "*.pdb" << "*.sln" << "*.suo";
    nameExcludeFilter << "*/buildFiles/Xcode/*";
+   nameExcludeFilter << "*/template.xml";
    QStringList nameIncludeFilter;
 
    connect(&mCopyDir, SIGNAL(updateFileCount(int)), this, SLOT(updateCreateProjectCount(int)));
    connect(&mCopyDir, SIGNAL(updateFileProgress(int, QString)), this, SLOT(updateCreateProjectProgress(int, QString)));
    connect(&mCopyDir, SIGNAL(fileCopyDone(bool, bool)), this, SLOT(updateCreateProjectDone(bool, bool)));
    connect(&mCopyDir, SIGNAL(fileCopyDone(bool, bool)), &mCopyDir, SLOT(quit()));
-   mCopyDir.setValues(mTemplateDir.path(), mNewProjectDir.path(), nameExcludeFilter, nameIncludeFilter);
+   QStringList dirs = mPackagePaths;
+   dirs.push_front(mTemplateDir.path());
+   mCopyDir.setValues(dirs, mNewProjectDir.path(), nameExcludeFilter, nameIncludeFilter);
    mCopyDir.start();
 }
 

--- a/source/torque3dfrontloader.h
+++ b/source/torque3dfrontloader.h
@@ -110,7 +110,7 @@ public:
    void replaceTextInFile(QString file, QString srcText, QString dstText);
    void createNewProject(const QString &templatePath, const QString &newProjectPath, ModuleListInstance* moduleInst);
 
-   QPixmap *getProjectPixmap(ProjectEntry *entry);
+   QPixmap *getProjectPixmap(DirEntry *entry);
 
    void renameFile(const QString &filePath, const QString &newName);
    void renameMacApp(const QString &filePath, const QString &oldName, const QString &bundleName, const QString &newName, const QString &newBundleName, bool processWebPlugin = false);

--- a/source/torque3dfrontloader.h
+++ b/source/torque3dfrontloader.h
@@ -108,7 +108,7 @@ public:
    void createProjectGeneration();
 	
    void replaceTextInFile(QString file, QString srcText, QString dstText);
-   void createNewProject(const QString &templatePath, const QString &newProjectPath, ModuleListInstance* moduleInst);
+   void createNewProject(const QString &templatePath, const QStringList &packagePaths, const QString &newProjectPath, ModuleListInstance* moduleInst);
 
    QPixmap *getProjectPixmap(DirEntry *entry);
 
@@ -256,6 +256,7 @@ private:
 
    QDir mTemplateDir;
    QDir mNewProjectDir;
+   QStringList mPackagePaths;
    ModuleListInstance* mNewProjectModuleList;
    ModuleListInstance* mChangeProjectModulesList;
 


### PR DESCRIPTION
With this change, the PM will scan template directories for a `template.xml` file in the template root (e.g. [`Full/template.xml`](https://github.com/eightyeight/Torque3D/blob/template-refactor/Templates/Full/template.xml)). This file determines which of the packages in the `Packages` directory next to the PM executable should be included when a new project is created from the template.

Currently, when you create a new project, the PM just copies the contents of the template you've chosen into the project folder. Now, it will _also_ copy the contents of every package named in `template.xml` with `inclusion="required"` or `inclusion="recommended"`. This means we can separate commonly-used bits of template out into packages, and include them by referring to them in `template.xml`.

This should have no effect on current project creation. There are also no UI changes.